### PR TITLE
replace usage of "-" with "|"

### DIFF
--- a/spotify_remote.py
+++ b/spotify_remote.py
@@ -25,7 +25,7 @@ class SpotifyRemote:
 
     def get_title_from_track(self, track):
         artists = ", ".join([artist.name for artist in track.artists])
-        return "{} - {}".format(artists, track.name)
+        return "{} | {}".format(artists, track.name)
 
     def get_track_preview(self, uri):
         id = tekore.from_uri(uri)[1]

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -339,7 +339,7 @@ class TelegramBot:
                                     self.spotify.get_title_from_track(
                                         currently_playing.item
                                     )
-                                    .split("-")[-1]
+                                    .split("|")[-1]
                                     .strip()
                                 )
                                 self.send_message(


### PR DESCRIPTION
using - to combine artist name and song name is a bad idea since that character also appears in artist and song names. Thus we can't split well using it.